### PR TITLE
Use consistent font families

### DIFF
--- a/src/lib/components/styles/style.css
+++ b/src/lib/components/styles/style.css
@@ -1,5 +1,5 @@
 .rw-container {
-	font-family: 'Open Sans', 'sans-serif';
+	font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
 	font-size: 1rem;
   }
   


### PR DESCRIPTION
The existing font family list did not contain one that supported MacOS, I just copied the list from SSW.Rules