### PR TITLE
✨ Get Widget data using commits.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "widget",
     "standards"
   ],
-  "version": "1.4.2",
+  "version": "1.5.2",
   "private": false,
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,9 @@
-import Widget from './lib/components/Widget'
+import { RulesWidget } from './lib';
 
 function App() {
   return (
     <div className="App">
-      <Widget isDarkMode={true} numberOfRules={5} token={process.env.REACT_APP_GITHUB_PAT} location={window.location}></Widget>
+      <RulesWidget />
     </div>
   );
 }

--- a/src/lib/components/RulesWidget.js
+++ b/src/lib/components/RulesWidget.js
@@ -49,7 +49,8 @@ export default function RulesWidget({
         }       
         async function filterData(json){
             const editorData = json.find(x => x.user === ruleEditor) || { commits: []};
-            return flattenData(editorData.commits)
+            let filteredData = flattenData(editorData.commits)
+            return filteredData.length > ruleCount ? filteredData.splice(0, ruleCount) : filteredData;
         }
 
         function flattenData(oldCommitData) {

--- a/src/lib/components/RulesWidget.js
+++ b/src/lib/components/RulesWidget.js
@@ -93,25 +93,36 @@ export default function RulesWidget({
             )
         else if(data) {
             return(
-                data.map((item, idx) => {
-                    return (<a
-                        key={idx}
-                        rel="noreferrer"
-                        target="_blank"
-                        href={`${rulesUrl}/${item.uri}`}
-                    >
-                        <div className="rw-rule-card" key={idx}>
-                            <p className="rw-rule-title">{item.title}</p>
-                            <p className="rw-rule-details">
-                                <FontAwesomeIcon
-                                    icon={faClock}
-                                    className="clock"
-                                ></FontAwesomeIcon>{" "}
-                                {getLastUpdatedTime(item.updatedTime)} ago
-                            </p>
-                        </div>                            
-                    </a>)
-                })
+                <>
+                {
+                    data.map((item, idx) => {
+                        return (<a
+                            key={idx}
+                            rel="noreferrer"
+                            target="_blank"
+                            href={`${rulesUrl}/${item.uri}`}
+                        >
+                            <div className="rw-rule-card" key={idx}>
+                                <p className="rw-rule-title">{item.title}</p>
+                                <p className="rw-rule-details">
+                                    <FontAwesomeIcon
+                                        icon={faClock}
+                                        className="clock"
+                                    ></FontAwesomeIcon>{" "}
+                                    {getLastUpdatedTime(item.updatedTime)} ago
+                                </p>
+                            </div>                            
+                        </a>)
+                    })
+                }
+                {
+                    ruleEditor && !!data.length && (
+                    <div className="see-more-container">
+                        <a rel="noreferrer" target="_blank" className="rw-see-more" href={`${rulesUrl}latest-rules/?author=${ruleEditor}`}>See More</a>
+                    </div>
+                    )
+                }
+                </>
             )}
             
     }

--- a/src/lib/components/RulesWidget.js
+++ b/src/lib/components/RulesWidget.js
@@ -20,7 +20,6 @@ export default function RulesWidget({
     const [data, setData] = useState(null);
     const [error, setError] = useState(null);
     
-    //Fetch the rules from the rulesUrl
     useEffect(() =>{
         async function fetchData(){
             try {
@@ -35,20 +34,12 @@ export default function RulesWidget({
         async function filterData(json){
             let filteredData = json;
 
-            // if(ruleEditor) {
-            //     const userName = await fetchGithubName(ruleEditor)
-            //     filteredData = filteredData.filter(x => formatName(x.lastUpdatedBy) === userName && x.title !== "No title")
-            // }
-
             if (ruleEditor) {
-                console.log("ruleEditor:", ruleEditor)
-                console.log("filterData", filteredData)
                 filteredData = filteredData.filter(x => x.user === ruleEditor)
             }
 
             const widgetData = flattenData(filteredData[0].commits)
             // TODO: Get top 10 latest rules when there is no specific ruleEditor
-            // return filteredData.length > ruleCount ? filteredData[0].commits.splice(0, ruleCount) : filteredData;
             return widgetData
         }
 
@@ -71,29 +62,8 @@ export default function RulesWidget({
             return newCommitData
         }
 
-        async function fetchGithubName(ruleEditor) {
-            try {
-                const response = await fetch(`https://api.github.com/users/${ruleEditor}`, {
-                    method: "GET",
-                    headers: {
-                        Authorization: token ? `bearer ${token}` : "",
-                    }
-                })
-
-                const { name } = await response.json();
-                return formatName(name)
-            } catch (error) {
-                throw error;
-            }
-        }
-
         fetchData();
     }, [rulesUrl, ruleCount, ruleEditor, token])
-
-    function formatName(name) {
-        if (!name) return
-        return name.replace("[SSW]", "").replace(/\s/g, "").toLowerCase()
-    }
 
     function getLastUpdatedTime(lastUpdatedDate){
         return formatDistanceStrict(
@@ -113,7 +83,6 @@ export default function RulesWidget({
                 <p>There was an error: {error.message}</p>
             )
         else if(data) {
-            console.log("???", data)
             return(
                 data.map((item, idx) => {
                     return (<a

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,3 +1,3 @@
-import Widget from './components/Widget';
+import RulesWidget from './components/RulesWidget';
 
-export { Widget };
+export { RulesWidget };


### PR DESCRIPTION
Relates to https://github.com/SSWConsulting/SSW.Rules.Widget/issues/39

Changes:
- Use commits.json for Widget data in cases where an author is present
- Keep using the GitHub API when there's no author

![image](https://github.com/SSWConsulting/SSW.Rules.Widget/assets/127192800/686f56d1-4b45-4b90-a482-8d82aba9cfa0)
**Figure: fetch the commits.json instead of using multiple GitHub APIs**