### PR TITLE
🐛 Update "See More" Link to Navigate to Correct User Rules Page

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "widget",
     "standards"
   ],
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": false,
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/lib/components/RulesWidget.js
+++ b/src/lib/components/RulesWidget.js
@@ -8,6 +8,7 @@ import "./styles/style.css";
 
 export default function RulesWidget({
     rulesUrl = 'https://www.ssw.com.au/rules',
+    userRulesUrl = 'https://ssw.com.au/rules/user-rules/?author=',
     showLogo,
     location = window.location.href,
     ruleCount = 10,
@@ -119,7 +120,7 @@ export default function RulesWidget({
                 {
                     ruleEditor && !!data.length && (
                     <div className="see-more-container">
-                        <a rel="noreferrer" target="_blank" className="rw-see-more" href={`${rulesUrl}latest-rules/?author=${ruleEditor}`}>See More</a>
+                        <a rel="noreferrer" target="_blank" className="rw-see-more" href={`${userRulesUrl}${ruleEditor}`}>See More</a>
                     </div>
                     )
                 }


### PR DESCRIPTION
The current "See More" directs users to the wrong page (e.g. https://www.ssw.com.au/rules/latest-rules/?author=Aibono1225), I am updating it to the correct one (e.g. https://ssw.com.au/rules/user-rules/?author=Aibono1225)