### PR TITLE
Update readme and ES version

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ function ExamplePage() {
       <RulesWidget />
 
       /* Using all the options */
-      <RulesWidget latestRulesUrl={"#"} skip={5} rulesUrl={"#"} userRulesUrl={"#?="} showLogo={true} numberOfRules={5} author={authorGitHubUsername} location={window.location}/>
+      <RulesWidget skip={5} rulesUrl={"#"} userRulesUrl={"#?="} showLogo={true} numberOfRules={5} author={authorGitHubUsername} location={window.location}/>
     </>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssw.rules.widget",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ssw.rules.widget",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.14.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "widget",
     "standards"
   ],
-  "version": "2.0.4",
+  "version": "2.0.5",
   "license": "MIT",
   "main": "dist/ssw.rules.widget.cjs.js",
   "module": "dist/ssw.rules.widget.es.js",

--- a/src/lib/widget/widget.tsx
+++ b/src/lib/widget/widget.tsx
@@ -7,7 +7,7 @@ import "./styles.css";
 const historyJsonUrl = import.meta.env.VITE_HISTORY_JSON_URL;
 const commitsJsonUrl = import.meta.env.VITE_COMMITS_JSON_URL;
 
-interface WidgetProps {
+export interface WidgetProps {
   rulesUrl?: string;
   userRulesUrl?: string;
   showLogo?: boolean;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES6",
-    "lib": ["ES6", "DOM", "DOM.Iterable"],
-    "module": "ES6",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ES2022",
     "moduleResolution": "Node",
     "declaration": true,
     "outDir": "./dist",


### PR DESCRIPTION
- Updated readme of npm package
- Updated from ES6 to ES2022, because the `import.meta.env` was giving an error when publishing package but not running it locally