### PR TITLE
♻️ Fix widget for SSW People Staging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssw.rules.widget",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ssw.rules.widget",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.14.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "widget",
     "standards"
   ],
-  "version": "2.0.7",
+  "version": "2.0.8",
   "license": "MIT",
   "main": "dist/ssw.rules.widget.cjs.js",
   "module": "dist/ssw.rules.widget.es.js",

--- a/src/lib/widget/widget-constants.enum.ts
+++ b/src/lib/widget/widget-constants.enum.ts
@@ -5,4 +5,6 @@ export enum WidgetConstants {
   ProdLatestRulesUrl = "https://www.ssw.com.au/rules/latest-rules/?size=50",
   StagingLatestRulesUrl = "https://sarulesstagbbfslamgwndh2.z8.web.core.windows.net/rules/latest-rules/?size=50",
   UserRulesUrl = "https://www.ssw.com.au/rules/user/?author=",
+  ProdPeopleUrl = "https://www.ssw.com.au/people",
+  StagingPeopleUrl = "https://sapeoplestagjthgmptzb46i.z8.web.core.windows.net/people",
 }

--- a/src/lib/widget/widget.tsx
+++ b/src/lib/widget/widget.tsx
@@ -53,7 +53,10 @@ const Widget = ({
   let historyJsonUrl = import.meta.env.VITE_PROD_HISTORY_JSON_URL;
   let commitsJsonUrl = import.meta.env.VITE_PROD_COMMITS_JSON_URL;
 
-  if (location === WidgetConstants.StagingRulesUrl) {
+  if (
+    location === WidgetConstants.StagingRulesUrl ||
+    location === WidgetConstants.StagingPeopleUrl
+  ) {
     rulesUrl = WidgetConstants.StagingRulesUrl;
     latestRulesUrl = WidgetConstants.StagingLatestRulesUrl;
     historyJsonUrl = import.meta.env.VITE_STAGING_HISTORY_JSON_URL;
@@ -214,11 +217,7 @@ const Widget = ({
           location === WidgetConstants.StagingRulesUrl ? (
             "Latest Rules"
           ) : (
-            <a
-              rel="noreferrer"
-              target="_blank"
-              href={`${WidgetConstants.ProdLatestRulesUrl}`}
-            >
+            <a rel="noreferrer" target="_blank" href={`${latestRulesUrl}`}>
               Latest Rules
             </a>
           )}


### PR DESCRIPTION
Issue: https://github.com/SSWConsulting/SSW.Rules/issues/1642

SSW People Staging was failing to show widget

Refactored the widget logic to use SSW Rules Staging URL to get `history.json` and `commits.json` data when the widget is used on SSW People Staging

Published package, then tested SSW Rules and SSW People in local
All is working as expected ✅

Here is PRs for SSW Rules and SSW People:
- https://github.com/SSWConsulting/SSW.People/pull/704
- https://github.com/SSWConsulting/SSW.Rules/pull/1646

![0F115CF3-DB59-4F88-9CCC-D07D8352CC40](https://github.com/user-attachments/assets/63857f75-0162-4aae-b9ca-faa0aafba83a)
**Figure: SSW Rules locally is displaying widget**

![59D430E1-F156-426A-8548-13DCB26A77A4](https://github.com/user-attachments/assets/7546f87c-72f6-4cd1-abec-19fd654cfd48)
**Figure: SSW People locally is displaying widget**


